### PR TITLE
User system rewrite

### DIFF
--- a/src/commands/economy.js
+++ b/src/commands/economy.js
@@ -10,22 +10,22 @@ module.exports = [
         async run(message, args, client) {
             let user = message.mentions.users.first() || message.author
 
-            let userData = client.economy.getUser(user.id)
+            let xilefUser = client.economy.getUser(user.id)
 
             const embeds = [
                 new MessageEmbed()
                     .setColor(message.member.displayHexColor)
                     .setTitle(user.username + "'s statistics")
-                    .setDescription("```lua\nDogeCoins: " + userData.money +
-                        "\nRank: " + userData.rank + "```")
+                    .setDescription("```lua\nDogeCoins: " + xilefUser.data.money +
+                        "\nRank: " + xilefUser.data.rank + "```")
                     .addFields({
                         name: "Achievements: ",
-                        value: userData.achievements.getFormattedBinary(achievements.binary, "❔ ???\n")
+                        value: xilefUser.data.achievements.getFormattedBinary(achievements.binary, "❔ ???\n")
                     }),
                 new MessageEmbed()
                     .setColor(message.member.displayHexColor)
                     .setTitle(user.username + "'s statistics")
-                    .setDescription("Acquired v_s: \n" + userData.vgot.getFormattedBinary(funnyFaces.binary, "❔"))
+                    .setDescription("Acquired v_s: \n" + xilefUser.data.vgot.getFormattedBinary(funnyFaces.binary, "❔"))
                 ]
 
                 /*+

--- a/src/commands/minigames/crew.js
+++ b/src/commands/minigames/crew.js
@@ -16,7 +16,6 @@ const suspiciousnessMessages = [
     " just vented!"
 ]
 
-
 const crewNames = ["red", "blue", "green", "pink", "orange", "yellow", "black", "white", "purple", "cyan"]
 
 class AmongusGame {
@@ -140,10 +139,11 @@ module.exports = [
                     args[0] = args[0].toLowerCase()
 
                     let impostor = gameInstance.getImpostorColor()
-                    // const userData = client.economy.getUser(message.author.id)
+                    const userData = client.economy.getUser(message.author.id)
 
                     if (args[0] == impostor) {
                         message.reply("You won!")
+                        userData.give(30, () => { message.channel.send("You earned 30 DogeCoins, use them wisely. ")})
                     } else {
                         message.reply("You lost!")
                     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ const eventLogger = Logger.create("event", {
 
 fs.stat('./src/data/logs', (err, stat) => {
     if (stat.size > 4096) {
-        fs.rmdirSync('./src/data/logs', { force: true })
+        fs.rmSync('./src/data/logs', { force: true, recursive: true })
         fs.mkdirSync('./src/data/logs')
     }
 })

--- a/src/economy.js
+++ b/src/economy.js
@@ -244,7 +244,10 @@ class EconomySystem {
         return new XilefUser(user, this.#users.get(user.id ?? user), { update: this.#updateBson.bind(this, null) })
     }
 
-    setUser(discordId, xilefUser) {
+    setUser(discordId, xilefUserData) {
+        if (!xilefUserData instanceof XilefUserData) 
+            throw "You need to set a valid XilefUserData instance"
+            
         if (!this.#users.get(discordId)) {
             economyLogger.log(`created a new instance of a user: <${discordId}>`)
         }

--- a/src/economy.js
+++ b/src/economy.js
@@ -76,14 +76,14 @@ class UserBinaryData {
     }
 }
 
-class XilefUser {
+class XilefUserData {
     constructor(options) {
         const optionsKeys = Object.keys(options)
         if (
             !optionsKeys.includes("money") ||
             !optionsKeys.includes("rank")
         )
-            throw new Error("Missing required key of XilefUser")
+            throw new Error("Missing required key of XilefUserData")
 
         this.money = options.money
         this.rank = options.rank
@@ -94,7 +94,7 @@ class XilefUser {
     }
 
     static getEmptyUser() {
-        return new XilefUser({
+        return new XilefUserData({
             money: 0,
             rank: 0,
             vgot: new UserBinaryData(60, "0"),
@@ -105,14 +105,14 @@ class XilefUser {
 
 class EconomySystem {
     /**
-     * @type {Collection<String, XilefUser>}
+     * @type {Collection<String, XilefUserData>}
      */
     #users
 
     constructor() {
         this.#users = new Collection()
 
-        this.setUser("830008177156292609", new XilefUser({
+        this.setUser("830008177156292609", new XilefUserData({
             money: -1,
             rank: -1,
             vgot: new UserBinaryData(60, "1".repeat(60)),
@@ -137,7 +137,7 @@ class EconomySystem {
             const userCreationOptions = {}
             Object.assign(userCreationOptions, rawUserData)
 
-            this.#users.set(key, new XilefUser(userCreationOptions))
+            this.#users.set(key, new XilefUserData(userCreationOptions))
             economyLogger.log(`Loaded <${key}> from economy.bson \n(${JSON.stringify(userCreationOptions)})`)
         })
 
@@ -157,7 +157,7 @@ class EconomySystem {
      */
     getUser(discordId) {
         if (!this.#users.get(discordId) && typeof discordId == "string") {
-            this.setUser(discordId, XilefUser.getEmptyUser())
+            this.setUser(discordId, XilefUserData.getEmptyUser())
         }
         return this.#users.get(discordId)
     }
@@ -175,6 +175,6 @@ class EconomySystem {
 
 module.exports = {
     EconomySystem,
-    XilefUser
+    XilefUser: XilefUserData
 }
 

--- a/src/economy.js
+++ b/src/economy.js
@@ -278,6 +278,7 @@ class EconomySystem {
 module.exports = {
     EconomySystem,
     XilefUser,
-    XilefUserData
+    XilefUserData,
+    UserBinaryData
 }
 


### PR DESCRIPTION
This PR:
Addresses #21 by, as its main feature, creating a new XilefUser class for convenience purposes.

It still has one major problem : serialization.
Currently, every time a change is made to the XUData instance that the new XU class holds, the entire economysystem instance that the localclient holds is serialized. This can be pretty heavy on the disk and CPU, and I have come up with a solution, which would consist in : 
- Every time a change is done to a user instance, that change is "counted" on some sort of global counter. 
- When the global counter reaches a certain count, like 30 changes for instance, the entire economy is serialized, and the counter is reset. When debugging, the threshold for the counter could be reduced to 5 - 10 changes for instance; or it could be signified as a whole other command-line argument (like --max-change-count=value)

This may cause some issues related to thread-safety but I can't think of anything better - other than using an asynchronous setInterval function, although it isn't really safe and still implies a very regular usage of disk; not the best idea.

There may just very well be a better option, but I can't seem to think of it. 